### PR TITLE
Pin down ssh-agent:1.21

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -78,7 +78,7 @@ prometheus:2.0.9
 scm-api:2.6.4
 scm-filter-branch-pr:0.5.1
 script-security:1.76
-ssh-agent:1.22
+ssh-agent:1.21
 ssh-credentials:1.18.1
 support-core:2.72.1
 timestamper:1.12

--- a/plugins.txt
+++ b/plugins.txt
@@ -78,7 +78,7 @@ prometheus:2.0.9
 scm-api:2.6.4
 scm-filter-branch-pr:0.5.1
 script-security:1.76
-ssh-agent:1.21
+ssh-agent:1.21 # noupdate
 ssh-credentials:1.18.1
 support-core:2.72.1
 timestamper:1.12


### PR DESCRIPTION
The ssh agent is failing for the windows job.
As suggested by @daniel-beck, the latest ssh-agent version introduced a breaking change  should use version 1.21 until we improve the ssh command from the windows container

https://updates.jenkins.io/download/plugins/ssh-agent/1.22/ssh-agent.hpi