### PR TITLE
fix: remove github-api plugin from explicit dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+hadolint.json
+*.tar

--- a/cst.yml
+++ b/cst.yml
@@ -16,6 +16,15 @@ fileExistenceTests:
   - name: 'default plugin - configuration-as-code'
     path: '/usr/share/jenkins/ref/plugins/configuration-as-code.jpi'
     shouldExist: true
+  - name: 'EC2 Agents'
+    path: '/usr/share/jenkins/ref/plugins/ec2.jpi'
+    shouldExist: true
+  - name: 'Azure VM Agents'
+    path: '/usr/share/jenkins/ref/plugins/azure-vm-agents.jpi'
+    shouldExist: true
+  - name: 'Azure Container Agents'
+    path: '/usr/share/jenkins/ref/plugins/azure-container-agents.jpi'
+    shouldExist: true
   - name: 'OpenTelemetry Plugin'
     path: '/usr/share/jenkins/ref/plugins/opentelemetry.jpi'
     shouldExist: true

--- a/plugins.txt
+++ b/plugins.txt
@@ -41,7 +41,6 @@ git:4.7.2
 git-client:3.7.2
 git-forensics:1.0.0
 github:1.33.1
-github-api:1.222
 github-autostatus:3.6.2
 github-branch-source:2.11.1
 github-checks:1.0.12


### PR DESCRIPTION
CloudBees Health Advisor report mentioned this plugin to be "no longer distributed",
as we were explicitly installing a "not recommended" version.

- https://support.cloudbees.com/hc/en-us/articles/4402425444635
- https://github.com/jenkins-infra/update-center2/blob/master/resources/artifact-ignores.properties#L560

This commit removes the explicit from plugins.txt and delegates
github-api installation to transitive dependencies.

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>
