### PR TITLE
feat(plugins) Bump ssh-agent to 1.24.1 + enable update on it

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -79,7 +79,7 @@ prometheus:2.0.10
 scm-api:595.vd5a_df5eb_0e39
 scm-filter-branch-pr:0.5.1
 script-security:1131.v8b_b_5eda_c328e
-ssh-agent:1.21 # noupdate
+ssh-agent:1.24.1
 ssh-credentials:1.19
 support-core:2.79
 timestamper:1.16


### PR DESCRIPTION
On release.ci.jenkins.ion, we have this admin message:

<img width="614" alt="Capture d’écran 2022-01-27 à 10 29 20" src="https://user-images.githubusercontent.com/1522731/151331238-babf1f59-0a64-4a8b-859c-aa0f2405785f.png">


The SSH-agent plugin was pinned (1 year ago) and marked as "noupdate" because it was failing for multiple consecutive releases.
But it was stabilized and it make sense to enable it again (+ security!)