### PR TITLE
Bump Jenkins base image to `2.346.3-2` (latest packaged version for LTS 2.346.3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.346.3-jdk11
+FROM jenkins/jenkins:2.346.3-2-jdk11
 
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt --verbose


### PR DESCRIPTION
Ref. https://github.com/jenkinsci/docker/issues/1441#issuecomment-1228140417