### PR TITLE
Revert "chore: remove `pipeline-utility-step` plugin"

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -129,6 +129,7 @@ pipeline-rest-api:2.27
 pipeline-stage-step:296.v5f6908f017a_5
 pipeline-stage-tags-metadata:2.2118.v31fd5b_9944b_5
 pipeline-stage-view:2.27
+pipeline-utility-steps:2.14.0
 plain-credentials:139.ved2b_9cf7587b
 plugin-util-api:2.18.0
 popper2-api:2.11.6-2


### PR DESCRIPTION
Reverts jenkins-infra/docker-jenkins-lts#631 until https://github.com/jenkins-infra/release/issues/313 is resolved.