### PR TITLE
Remove handlebars plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -75,7 +75,6 @@ github-branch-source:1701.v00cc8184df93
 github-checks:1.0.19
 github-label-filter:1.0.0
 groovy:453.vcdb_a_c5c99890
-handlebars:3.0.8
 handy-uri-templates-2-api:2.1.8-22.v77d5b_75e6953
 htmlpublisher:1.31
 inline-pipeline:1.0.2


### PR DESCRIPTION
The plugin is [deprecated](https://plugins.jenkins.io/handlebars/) and there is no trace another plugin depends on it, given you can uninstall it from the web ui.
I recommend we remove it from the docker image.