### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number (#695

### DIFF
--- a/.github/workflows/latest-lts.yaml
+++ b/.github/workflows/latest-lts.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Jenkins LTS version
         id: update
-        uses: jenkins-infra/jenkins-version@f7169071ddca27403a722c13815f6c6c593da62a # 0.3.1
+        uses: jenkins-infra/jenkins-version@0.3.1
         with:
           version-identifier: lts
       - name: Process Version
@@ -33,7 +33,7 @@ jobs:
           fi
       - name: Update
         if: ${{ steps.diff.outputs.changed == 'true' }}
-        uses: jenkins-infra/uc@b93acb50d659a87ba7a77e0c4f0bf76842a4332d # 0.1.4
+        uses: jenkins-infra/uc@0.1.4
       - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8
         id: generate-token
         with:

--- a/.github/workflows/latest-lts.yaml
+++ b/.github/workflows/latest-lts.yaml
@@ -1,24 +1,19 @@
----
 name: latest-lts
-
 on:
   schedule:
     - cron: "*/15 * * * *"
   workflow_dispatch:
-
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
-
       - name: Jenkins LTS version
         id: update
-        uses: jenkins-infra/jenkins-version@0.3.1
+        uses: jenkins-infra/jenkins-version@f7169071ddca27403a722c13815f6c6c593da62a # 0.3.1
         with:
           version-identifier: lts
-
       - name: Process Version
         id: process
         run: |
@@ -26,7 +21,6 @@ jobs:
           FULL_VERSION=jenkins/jenkins:${{ steps.update.outputs.jenkins_version }}-${SUFFIX}
           echo $FULL_VERSION
           sed -i 's|FROM .*|FROM '"${FULL_VERSION}"'|' Dockerfile
-
       - name: Calculate Diff
         id: diff
         run: |
@@ -37,20 +31,17 @@ jobs:
           else
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
-
       - name: Update
         if: ${{ steps.diff.outputs.changed == 'true' }}
-        uses: jenkins-infra/uc@0.1.4
-
-      - uses: tibdex/github-app-token@v1.8
+        uses: jenkins-infra/uc@b93acb50d659a87ba7a77e0c4f0bf76842a4332d # 0.1.4
+      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8
         id: generate-token
         with:
           app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
-
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4
         with:
           commit-message: 'feat(deps): bump jenkins lts to ${{ steps.update.outputs.jenkins_version }}'
           signoff: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,14 +1,10 @@
----
 name: cd
 on:
   push:
   workflow_dispatch:
   release:
-
 # Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases
 concurrency: "release-drafter"
-
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,9 +13,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Release Drafter
-        uses: release-drafter/release-drafter@v5.23.0
+        uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5.23.0
         with:
           name: next
           tag: next

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,11 +1,8 @@
----
 name: Update plugins
-
 on:
   schedule:
     - cron: "*/15 * * * *"
   workflow_dispatch:
-
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -17,19 +14,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-
       - run: ./bin/update-plugins.sh
         name: Update plugins
-
-      - uses: tibdex/github-app-token@v1.8
+      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8
         id: generate-token
         with:
           app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
           private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
-
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4
         with:
           commit-message: 'chore(deps): update plugins'
           signoff: false


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402