### PR TITLE
cleanup: remove opentelemetry plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -112,7 +112,6 @@ mina-sshd-api-common:2.11.0-86.v836f585d47fa_
 mina-sshd-api-core:2.11.0-86.v836f585d47fa_
 node-iterator-api:55.v3b_77d4032326
 okhttp-api:4.11.0-157.v6852a_a_fa_ec11
-opentelemetry:2.18.0
 pipeline-build-step:516.v8ee60a_81c5b_9
 pipeline-github:2.8-155.8eab375ac9f8
 pipeline-graph-analysis:202.va_d268e64deb_3


### PR DESCRIPTION
The Jenkins Infra. is using datadog for today and alas does not have the capacity to maintain or use an Opentelemetry platform.

As such we've removed the plugin in infra.ci in https://github.com/jenkins-infra/docker-jenkins-weekly/commit/cfc3183548ce997a540fd5c6459eb9fe7139a155 some time ago: let's remove it here as well.

Of course no problem to revert when we'll start using an opentelemetry system which works well with Jenkins!