### PR TITLE
feat(plugins) remove github-autostatus as unneeded 

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -69,7 +69,6 @@ git-client:4.6.0
 git-forensics:2.0.0
 github:1.37.3.1
 github-api:1.318-461.v7a_c09c9fa_d63
-github-autostatus:3.6.2
 github-branch-source:1767.va_7d01ea_c7256
 github-checks:554.vb_ee03a_000f65
 github-label-filter:1.0.0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3880#issuecomment-1875108510

- This plugin has not been updated since 4 years (ref. https://plugins.jenkins.io/github-autostatus/dependencies/)
- It should be replaced by `github-checks` (https://plugins.jenkins.io/github-checks/)