### PR TITLE
feat: add an arm64 image version

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -5,6 +5,7 @@ retry(3) {
     try {
         timeout(time: 30, unit: 'MINUTES') {
             buildDockerAndPublishImage('jenkins-lts', [
+                targetplatforms: 'linux/amd64,linux/arm64',
                 automaticSemanticVersioning: true,
                 gitCredentials: 'github-app-infra',
                 nextVersionCommand: 'echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4042

need a arm64 version for docker-lts