### PR TITLE
chore(Dockerfile) use the new UC for downloading plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ COPY logos /usr/share/jenkins/ref/userContent/logos
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli \
   --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
-  --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+  --jenkins-plugin-info='https://azure.updates.jenkins.io/plugin-versions.json' \
   --plugin-file /usr/share/jenkins/ref/plugins.txt \
   --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,8 @@ FROM jenkins/jenkins:2.462.1-jdk17
 
 COPY logos /usr/share/jenkins/ref/userContent/logos
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt --verbose
+RUN jenkins-plugin-cli \
+  --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
+  --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+  --plugin-file /usr/share/jenkins/ref/plugins.txt \
+  --verbose

--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -32,7 +32,7 @@ for pluginfile in ${list}; do
         java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" \
             --plugin-file "${pluginfile}" \
             --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
-            --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+            --jenkins-plugin-info='https://azure.updates.jenkins.io/plugin-versions.json' \
             --available-updates \
             --output txt \
             --war "${TMP_DIR}/jenkins.war" \

--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+list="plugins-*.txt"
+if [[ "$#" -eq 1 ]]; then
+    list=$1
+fi
+
 cd "$(dirname "$0")" || exit 1
 
 echo "Updating plugins"
@@ -19,12 +24,24 @@ wget --no-verbose "https://get.jenkins.io/war-stable/${CURRENT_JENKINS_VERSION}/
 
 cd ../ || exit 1
 
-java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" -f plugins.txt --available-updates --output txt --war "${TMP_DIR}/jenkins.war"  > plugins2.txt
+# Iterate through each txt file starting with "plugins-", or the file specified as input
+for pluginfile in ${list}; do
+    if [ -e "${pluginfile}" ]; then
+        echo "Updating plugins file: ${pluginfile}"
 
-mv plugins2.txt plugins.txt
+        java -jar "${TMP_DIR}/jenkins-plugin-manager.jar" \
+            --plugin-file "${pluginfile}" \
+            --jenkins-update-center='https://azure.updates.jenkins.io/update-center.json' \
+            --jenkins-plugin-info='https://azure.updates.jenkins.io/update-center.json' \
+            --available-updates \
+            --output txt \
+            --war "${TMP_DIR}/jenkins.war" \
+        > plugins2.txt
 
-git diff plugins.txt
-
-echo "Updating plugins complete"
+        mv plugins2.txt "${pluginfile}"
+    fi
+done
 
 rm -rf "${TMP_DIR}"
+
+echo "Updating plugins complete"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2283576911

This PR switches both the GHA shell script and the Dockerfile to use the [new `azure.updates.jenkins.io` Update Center](https://github.com/jenkins-infra/helpdesk/issues/2649) as part of the early testing.

The goal for us is to get confidence in using it before planning full scale deployment.