### PR TITLE
chore: verify checksum of plugin installation manager tool before executing

### DIFF
--- a/bin/update-plugins.sh
+++ b/bin/update-plugins.sh
@@ -19,6 +19,11 @@ TMP_DIR=$(mktemp -d)
 
 wget --no-verbose "${PM_CLI_DOWNLOAD_URL}" -O "${TMP_DIR}/jenkins-plugin-manager.jar"
 
+# Retrieve and check the corresponding sha256 checksum
+echo "$(curl --fail --silent --show-error --location "${PM_CLI_DOWNLOAD_URL}.sha256")  ${TMP_DIR}/jenkins-plugin-manager.jar" > /tmp/jenkins_sha
+sha256sum --check --strict /tmp/jenkins_sha
+rm -f /tmp/jenkins_sha
+
 CURRENT_JENKINS_VERSION=$(head -n 1 ../Dockerfile | cut -d ':' -f 2 | cut -d '-' -f 1)
 wget --no-verbose "https://get.jenkins.io/war-stable/${CURRENT_JENKINS_VERSION}/jenkins.war" -O "${TMP_DIR}/jenkins.war"
 


### PR DESCRIPTION
Fixes #865 

Tested on a fork:
```
+ PM_CLI_DOWNLOAD_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.13.2/jenkins-plugin-manager-2.13.2.jar
++ mktemp -d
+ TMP_DIR=/tmp/tmp.Hugs6MPUDq
+ wget --no-verbose https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.13.2/jenkins-plugin-manager-2.13.2.jar -O /tmp/tmp.Hugs6MPUDq/jenkins-plugin-manager.jar
2025-03-15 16:51:45 URL:https://objects.githubusercontent.com/<snip>%20filename%3Djenkins-plugin-manager-2.13.2.jar&response-content-type=application%2Foctet-stream [6945015/6945015] -> "/tmp/tmp.Hugs6MPUDq/jenkins-plugin-manager.jar" [1]
++ curl --fail --silent --show-error --location https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.13.2/jenkins-plugin-manager-2.13.2.jar.sha256
+ echo '98cdd261c64a4f51fbbf161287be77c9dbd0acb0c[58](https://github.com/lemeurherveCB/docker-jenkins-lts/actions/runs/13874812564/job/38825773423#step:4:59)b1916fdbc9dce03b47f9c  /tmp/tmp.Hugs6MPUDq/jenkins-plugin-manager.jar'
+ sha256sum --check --strict /tmp/jenkins_sha
/tmp/tmp.Hugs6MPUDq/jenkins-plugin-manager.jar: OK
+ rm -f /tmp/jenkins_sha
```