### PR TITLE
chore(Jenkinsfile_k8s) fail fast when get next version return empty or half-empty values

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,7 @@
 buildDockerAndPublishImage('jenkins-lts', [
     publishToPrivateAzureRegistry: true,
     targetplatforms: 'linux/arm64',
-    nextVersionCommand: 'git gc && echo "$(jx-release-version -next-version=semantic:strip-prerelease)-$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)"',
+    // The following command must return an exit code different than zero if jx-release-version or grep fail to find value. Hence the echo as last step.
+    // git gc ensures we don't run into https://github.com/jenkins-infra/docker-jenkins-lts/issues/1084
+    nextVersionCommand: 'git gc && semver="$(jx-release-version -next-version=semantic:strip-prerelease)" && prerelease="$(grep "FROM jenkins" Dockerfile | cut -d: -f2 | cut -d- -f1)" && echo "$semver"-"$prerelease"',
 ])


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/docker-jenkins-lts/issues/1084

- Tested without the `git gc` prefixed command: fails fast as expected (easier to track the issue):

<img width="1016" height="332" alt="Capture d’écran 2026-04-28 à 15 46 49" src="https://github.com/user-attachments/assets/0b8868fb-b077-4a9b-a969-abee4a48a684" />
<img width="1523" height="427" alt="Capture d’écran 2026-04-28 à 15 46 57" src="https://github.com/user-attachments/assets/ec46b5f1-692a-4ea5-86a3-562b12abecc4" />

- Tested with the `git gc` prefix: same outcome as https://github.com/jenkins-infra/docker-jenkins-lts/commit/cdbd1a30c4302de9b0ab7e5d754ff01eaf075da2