### PR TITLE
chore(Jenkinsfile_updatecli): restore daily cron trigger

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -3,7 +3,6 @@ final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds(abortPrevious: true),
-    pipelineTriggers([cron(cronExpr)]),
 ])
 
 node('linux-arm64-docker') {
@@ -12,6 +11,7 @@ node('linux-arm64-docker') {
         stage("Run updatecli action: ${updatecliAction}") {
             updatecli(
                 action: updatecliAction,
+                cronTriggerExpression: cronExpr,
                 runInCurrentAgent: true,
             )
         }


### PR DESCRIPTION
- Fixes the daily cron not firing jenkins-infra/helpdesk#5240.

The cron was set in the top-level `properties([pipelineTriggers(...)])`, but `updatecli()` calls `properties()` again internally and, with no `cronTriggerExpression` passed, discards the trigger. Moving the cron into the `updatecli()` call via `cronTriggerExpression` keeps it. Minimal change: drops the trigger from the top-level `properties()` and passes it to `updatecli()`.
